### PR TITLE
Brace Your Database

### DIFF
--- a/Insight.Database.Schema/Insight.Database.Schema.csproj
+++ b/Insight.Database.Schema/Insight.Database.Schema.csproj
@@ -36,11 +36,9 @@
     <Reference Include="Microsoft.SqlServer.Smo, Version=10.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Transactions" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Insight.Database.Schema/SchemaInstaller.cs
+++ b/Insight.Database.Schema/SchemaInstaller.cs
@@ -68,7 +68,7 @@ namespace Insight.Database.Schema
 
                 // only create the database if it doesn't exist
                 if (createDatabase)
-                    ExecuteNonQuery (String.Format (CultureInfo.InvariantCulture, "CREATE DATABASE {0}", _databaseName));
+                    ExecuteNonQuery (String.Format (CultureInfo.InvariantCulture, "CREATE DATABASE [{0}]", _databaseName));
 
                 return createDatabase;
             }
@@ -97,7 +97,7 @@ namespace Insight.Database.Schema
                 ExecuteNonQuery(String.Format(CultureInfo.InvariantCulture, "exec sp_dboption N'{0}', N'single', N'true'", _databaseName));
 
                 // drop the database
-                ExecuteNonQuery (String.Format (CultureInfo.InvariantCulture, "DROP DATABASE {0}", _databaseName));
+                ExecuteNonQuery (String.Format (CultureInfo.InvariantCulture, "DROP DATABASE [{0}]", _databaseName));
                 return true;
             }
         }


### PR DESCRIPTION
Insight's SchemaInstaller didn't like having periods within the database name.  I added escape braces around the database name in two queries to make it happy.  Tested fine locally.  I also cleanup some assembly references which weren't being used and probably were added automatically when upgrading to .NET 4.
