### PR TITLE
Invalid SQL Being generated by AutoProc Find when using ThenBy

### DIFF
--- a/Insight.Database.Schema/AutoProc.cs
+++ b/Insight.Database.Schema/AutoProc.cs
@@ -785,7 +785,7 @@ namespace Insight.Database.Schema
 			sb.AppendLine(") THEN @OrderBy ELSE ' ORDER BY INVALID COLUMN ' END");
 			sb.AppendLine("IF @OrderBy IS NOT NULL AND @ThenBy IS NOT NULL SET @sql = @sql + CASE WHEN @ThenBy IN (");
 			sb.AppendLine(Join(columns, ",", "'{0}', '{0} DESC'"));
-			sb.AppendLine(") THEN @ThenBy ELSE ' ORDER BY INVALID COLUMN ' END");
+			sb.AppendLine(") THEN ',' + @ThenBy ELSE ' ORDER BY INVALID COLUMN ' END");
 
             // handle top/skip -> offset/fetch
             // if skip is specified, convert TOP to OFFSET


### PR DESCRIPTION
I was having an issue using the @OrderBy and @ThenBy parameters for the Find autoproc. Debugging the proc, I noticed that a comma was not being inserted between the fields in the ORDER BY clause.

This consists of a one line fix to add a comma before the @ThenBy table name. 
