### PR TITLE
Changed AutoProc class visibility to public.

### DIFF
--- a/Insight.Database.Schema/AutoProc.cs
+++ b/Insight.Database.Schema/AutoProc.cs
@@ -17,7 +17,7 @@ namespace Insight.Database.Schema
 	///		AUTOPROC Insert [Beer] InsertBeer
 	///		GO
 	/// </summary>
-	class AutoProc
+	public class AutoProc
 	{
 		#region Private Members
 		/// <summary>
@@ -1055,7 +1055,7 @@ namespace Insight.Database.Schema
 		/// The types of stored procedures that we support.
 		/// </summary>
 		[Flags]
-		internal enum ProcTypes
+		public enum ProcTypes
 		{
 			Table = 1 << 0,
 			IdTable = 1 << 1,


### PR DESCRIPTION
In order to allow integration with custom stored procedure script generation solutions without using the SchemaInstaller which requires an IDbConnection or the schema parser. This way automatic script generation can be used without a real database and also custom IColumnDefinitionProvider implementation can be used as an input.

I'm working on a custom IColumnDefinitionProvider that reads .dacpac files to get column information. Dacpac files are the output of the Visual Studio Database Projects. This allows me to generate default CRUD stored procedures directly from a Database Project into an other Database Project without the need of an actual database. It works quite well, but I need to access the AutoProc class to do that. Would you mind making it public?
