### PR TITLE
Few minor issues & fixes.

### DIFF
--- a/Insight.Database.Schema/Implementation/Permission.cs
+++ b/Insight.Database.Schema/Implementation/Permission.cs
@@ -21,7 +21,8 @@ namespace Insight.Database.Schema.Implementation
 			Match m = Regex.Match(Name.Original, String.Format(CultureInfo.InvariantCulture, @"(?<permission>\w+)\s+ON\s+(?<object>{0})\s+TO\s+(?<user>{0})", SqlParser.SqlNameExpression));
 
 			var userName = new SqlName(m.Groups["user"].Value, 1);
-			var objectName = new SqlName(m.Groups["object"].Value, 2);
+			var o = m.Groups["object"].Value;
+			var objectName = new SqlName(o, o.Contains("TYPE::[dbo]") ? 3 : 2);
 
 			var permissions = connection.QuerySql(@"SELECT PermissionName=p.permission_name, ObjectType=ISNULL(o.type_desc, p.class_desc)
 					FROM sys.database_principals u

--- a/Insight.Database.Schema/Implementation/SchemaImpl.cs
+++ b/Insight.Database.Schema/Implementation/SchemaImpl.cs
@@ -103,6 +103,8 @@ namespace Insight.Database.Schema.Implementation
 					return new Service(name, sql);
 				case SchemaObjectType.StoredProcedure:
 					return new StoredProcedure(name, sql);
+				case SchemaObjectType.SymmetricKey:
+					return new SymmetricKey(name, sql);
 				case SchemaObjectType.Table:
 					return new Table(name, sql);
 				case SchemaObjectType.Trigger:

--- a/Insight.Database.Schema/SchemaInstaller.cs
+++ b/Insight.Database.Schema/SchemaInstaller.cs
@@ -1198,7 +1198,7 @@ namespace Insight.Database.Schema
 		private void DropObjects(IEnumerable<SchemaRegistryEntry> dropObjects)
         {
             // drop objects
-            foreach (var dropObject in dropObjects)
+            foreach (var dropObject in dropObjects.Distinct())
             {
                 if (DroppingObject != null)
 					DroppingObject(this, new SchemaEventArgs(SchemaEventType.BeforeDrop, dropObject.ObjectName));


### PR DESCRIPTION
There were a few minor issues that I ran into/fixed.

1. I was getting a NullReferenceException in SchemaObject.SqlName with a SymmetricKey. Adding the SchemaObjectType.SymmetricKey case in SchemaImp.GetImplementation fixed that issue.

2. I had a stored procedure that used a view. I changed the view and deleted the stored procedure. The dependency check automatically dropped the stored procedure, this caused the normal drop of the store procedure to fail stating that the stored procedure did not exist. The fix for this was to do a .Distinct() on the drop objects in SchemaInstaller.

3. I was getting an error stating that an EXECUTE right on a type was not in the database, when in fact it was. My script that creates the right was in the form: 
	`GRANT EXECUTE ON TYPE::[dbo].[MyTableType] TO [MyService]`
Permissions.Exists was not able to find this object. I fixed this by explicitly looking for "TYPE::[dbo]" and assume that SqlName will split that into 3 parts. This is the fix I'm least happy about. 
