### PR TITLE
Fixes an exception being thrown for Inline TVF dependencies

### DIFF
--- a/Insight.Database.Schema/SchemaInstaller.cs
+++ b/Insight.Database.Schema/SchemaInstaller.cs
@@ -871,6 +871,7 @@ namespace Insight.Database.Schema
 				{
 					case "SQL_STORED_PROCEDURE":
 					case "SQL_SCALAR_FUNCTION":
+					case "SQL_INLINE_TABLE_VALUED_FUNCTION":
 					case "SQL_TABLE_VALUED_FUNCTION":
 					case "SQL_TRIGGER":
 					case "VIEW":


### PR DESCRIPTION
Fixes #50 by adding `SQL_INLINE_TABLE_VALUED_FUNCTION` to "list" of supported dependency types.
