### PR TITLE
Change field operator parameter to varchar(11) to fit 'IS NOT NULL' #57

### DIFF
--- a/Insight.Database.Schema/AutoProc.cs
+++ b/Insight.Database.Schema/AutoProc.cs
@@ -844,7 +844,7 @@ namespace Insight.Database.Schema
 			sb.AppendLine("\t@OrderBy [nvarchar](256) = NULL,");
 			sb.AppendLine("\t@ThenBy [nvarchar](256) = NULL,");
 			sb.AppendLine("\t@TotalRows [int] = NULL OUTPUT,");
-			sb.AppendLine(Join(columns, ",", "{1}Operator [varchar](10) = '='"));
+			sb.AppendLine(Join(columns, ",", "{1}Operator [varchar](11) = '='"));
 			sb.AppendLine(")");
 			if (_executeAsOwner)
 				sb.AppendLine("WITH EXECUTE AS OWNER");


### PR DESCRIPTION
Fixes case where user wants to find a column that is not null but operator parameter too short to hold 'IS NOT NULL'.  
